### PR TITLE
Enable configuration validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 /dist
 /.github/changelog-generator-cache
 /tests/recursion.py
+tests/get_name_properties.py

--- a/jsonschema_gentypes/cli.py
+++ b/jsonschema_gentypes/cli.py
@@ -103,21 +103,20 @@ def main() -> None:
             ],
         }
     else:
-        schema_data = pkgutil.get_data("jsonschema_gentypes", "schema.json")
-        assert schema_data
         with open(args.config, encoding="utf-8") as data_file:
             data = yaml.load(data_file, Loader=yaml.SafeLoader)
         if args.skip_config_errors:
             print("Skipping configuration validation")
         else:
-            validate_config(schema_data, data)
+            validate_config(data)
         config = cast(configuration.Configuration, data)
 
     process_config(config, args.files)
 
 
-def validate_config(schema_data: bytes, config: Any):
-    # try:
+def validate_config(config: Any) -> None:
+    schema_data = pkgutil.get_data("jsonschema_gentypes", "schema.json")
+    assert schema_data
     schema = json.loads(schema_data)
     validator_class = validator_for(config)
     validator: Validator = validator_class(schema)

--- a/jsonschema_gentypes/cli.py
+++ b/jsonschema_gentypes/cli.py
@@ -3,6 +3,7 @@ Generate the Python type files from the JSON schema files.
 """
 
 import argparse
+import json
 import logging
 import os
 import pkgutil
@@ -10,9 +11,13 @@ import random
 import re
 import subprocess  # nosec
 import sys
+from collections.abc import Iterable
 from typing import Any, Callable, Optional, Union, cast
 
 import yaml
+from jsonschema import ValidationError
+from jsonschema.protocols import Validator
+from jsonschema.validators import validator_for
 
 import jsonschema_gentypes.api
 import jsonschema_gentypes.api_draft_04
@@ -102,9 +107,40 @@ def main() -> None:
         assert schema_data
         with open(args.config, encoding="utf-8") as data_file:
             data = yaml.load(data_file, Loader=yaml.SafeLoader)
+        if args.skip_config_errors:
+            print("Skipping configuration validation")
+        else:
+            validate_config(schema_data, data)
         config = cast(configuration.Configuration, data)
 
     process_config(config, args.files)
+
+
+def validate_config(schema_data: bytes, config: Any):
+    # try:
+    schema = json.loads(schema_data)
+    validator_class = validator_for(config)
+    validator: Validator = validator_class(schema)
+    errors = list(validator.iter_errors(config))
+    if errors and len(errors):
+        msg = "Validation Errors when validating configuration"
+        for error in validator.iter_errors(config):
+            path = create_json_path(error.relative_path)
+            if path:
+                msg = msg + f"\n  * {error.message} @ {path}"
+            else:
+                msg = msg + f"\n  * {error.message}"
+        raise ValidationError(msg)
+
+
+def create_json_path(elements: Iterable[Union[str, int]]) -> str:
+    path = ""
+    for el in elements:
+        if isinstance(el, int):
+            path = path + f"[{el}]"
+        else:
+            path = path + f".{el}" if path else el
+    return path
 
 
 class _AddType:

--- a/jsonschema_gentypes/cli.py
+++ b/jsonschema_gentypes/cli.py
@@ -121,7 +121,7 @@ def validate_config(config: Any) -> None:
     validator_class = validator_for(config)
     validator: Validator = validator_class(schema)
     errors = list(validator.iter_errors(config))
-    if errors and len(errors):
+    if errors and len(errors) > 0:
         msg = "Validation Errors when validating configuration"
         for error in validator.iter_errors(config):
             path = create_json_path(error.relative_path)
@@ -134,11 +134,11 @@ def validate_config(config: Any) -> None:
 
 def create_json_path(elements: Iterable[Union[str, int]]) -> str:
     path = ""
-    for el in elements:
-        if isinstance(el, int):
-            path = path + f"[{el}]"
+    for element in elements:
+        if isinstance(element, int):
+            path = path + f"[{element}]"
         else:
-            path = path + f".{el}" if path else el
+            path = path + f".{element}" if path else element
     return path
 
 

--- a/tests/get_name_properties.py
+++ b/tests/get_name_properties.py
@@ -1,4 +1,6 @@
-from typing import Required, TypedDict
+from typing import TypedDict
+
+from typing_extensions import Required
 
 
 class ResponseType(TypedDict, total=False):

--- a/tests/test_validate_config.py
+++ b/tests/test_validate_config.py
@@ -1,0 +1,30 @@
+from typing import cast
+
+import pytest
+from jsonschema import ValidationError
+
+from jsonschema_gentypes.cli import validate_config
+from jsonschema_gentypes.configuration import Configuration
+
+
+def test_validate_config() -> None:
+    config_valid: Configuration = Configuration(
+        generate=[
+            {
+                "source": "tests/get_name_properties.json",
+                "destination": "tests/get_name_properties.py",
+            }
+        ],
+    )
+
+    validate_config(config_valid)
+
+    config_bad = cast(dict, Configuration(config_valid))
+    config_bad["extra parameter"] = "bad parameter"
+    with pytest.raises(ValidationError):
+        validate_config(config_bad)
+
+    config_bad = cast(dict, Configuration(config_valid))
+    del config_bad["generate"][0]["source"]
+    with pytest.raises(ValidationError):
+        validate_config(config_bad)


### PR DESCRIPTION
jsonschema_gentype has a command line option to skip validating the provided configuration. Validation was actually also not performed when the flag was not set.

This pull request implement the validation of the configuration file, enables it by default, but allows skipping it if requested with the command line flag.